### PR TITLE
Get rid of global_env

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -194,7 +194,8 @@ Except for the order of evaluation, macros behave just like functions and can
 accept rest-arguments etc. the same way. Just like functions, you mostly want
 to define them before you use them, see [defm](#defm).
 
-**It is important to quote things that you do not want evaluated until after the macro has returned.**
+**It is important to quote things that you do not want evaluated until after
+the macro has returned.**
 
 ```clojure
 ; Note that we want `if` to be evaluated after the macro has returned, so we have to quote it.
@@ -206,7 +207,20 @@ to define them before you use them, see [defm](#defm).
 (reverse-if true "yes" "no") ; => "no"
 ```
 
-To debug macros and see what they expand to without trying to evaluate the result, see [macroexpand](#macroexpand).
+To debug macros and see what they expand to without trying to evaluate the
+result, see [macroexpand](#macroexpand).
+
+
+### require
+
+Loads and runs a Läsp file. Paths are relative to the file they are being
+required in.
+
+```clojure
+(require "lasp_file.lasp")     ; lasp_file.lasp is in the same directory as this code
+(require "dir/lasp_file.lasp") ; dir/ is a folder with a lasp file in this directory
+(require "../lasp_file.lasp")  ; lasp_file.lasp is in the parent folder
+```
 
 
 ## Core library
@@ -499,18 +513,6 @@ Parameters `(object message & args)`:
 ```ruby
 # Equal to this Ruby code:
 "01011101".to_i(2)
-```
-
-
-### require
-
-Loads and runs a Läsp file. Paths are relative to the file they are being
-required in.
-
-```clojure
-(require "lasp_file.lasp")     ; lasp_file.lasp is in the same directory as this code
-(require "dir/lasp_file.lasp") ; dir/ is a folder with a lasp file in this directory
-(require "../lasp_file.lasp")  ; lasp_file.lasp is in the parent folder
 ```
 
 

--- a/bin/lasp
+++ b/bin/lasp
@@ -2,10 +2,9 @@
 
 require "lasp"
 require "lasp/repl"
-Lasp::load_stdlib!
 
 if ARGV.first
-  Lasp::execute_file(ARGV.first)
+  Lasp::execute_file(ARGV.first, Lasp::env_with_stdlib)
 else
   Lasp::Repl.run
 end

--- a/lib/lasp.rb
+++ b/lib/lasp.rb
@@ -2,6 +2,7 @@ require "lasp/version"
 require "lasp/env"
 require "lasp/parser"
 require "lasp/interpreter"
+require "lasp/corelib"
 require "lasp/ext"
 
 module Lasp
@@ -9,15 +10,21 @@ module Lasp
 
   module_function
 
-  def execute_file(path)
-    execute("(do #{File.read(path)})")
-  end
-
-  def execute(program, env = global_env)
+  def execute(program, env = env_with_corelib)
     Interpreter.eval(Parser.parse(program), env)
   end
 
-  def load_stdlib!
-    Lasp::execute_file(STDLIB_PATH)
+  def execute_file(path, env = env_with_corelib)
+    execute("(do #{File.read(path)})", env)
+  end
+
+  def env_with_corelib
+    Env.new(CORELIB.dup)
+  end
+
+  def env_with_stdlib
+    env_with_corelib.tap do |env|
+      Lasp::execute_file(STDLIB_PATH, env)
+    end
   end
 end

--- a/lib/lasp/corelib.rb
+++ b/lib/lasp/corelib.rb
@@ -1,5 +1,3 @@
-require "lasp"
-
 module Lasp
   CORELIB = {
     :+          => -> (*args)         { args.reduce(:+)                            },
@@ -24,6 +22,5 @@ module Lasp
     :readln     => -> ()              { STDIN.gets.chomp                           },
     :apply      => -> (f, list)       { f.call(*list)                              },
     :"."        => -> (obj, m, *args) { obj.send(m, *args)                         },
-    :require    => -> (p)             { execute_file(File.expand_path(p, __dir__)) },
   }
 end

--- a/lib/lasp/env.rb
+++ b/lib/lasp/env.rb
@@ -1,9 +1,13 @@
-require "lasp/corelib"
+require "forwardable"
 
 module Lasp
-  module_function
+  class Env
+    extend Forwardable
 
-  def global_env
-    @global_env ||= {}.merge(CORELIB)
+    def_delegators :@env, :fetch, :merge, :[]=
+
+    def initialize(env = {})
+      @env = env
+    end
   end
 end

--- a/lib/lasp/interpreter.rb
+++ b/lib/lasp/interpreter.rb
@@ -1,3 +1,4 @@
+require "lasp"
 require "lasp/fn"
 require "lasp/macro"
 require "lasp/errors"
@@ -22,12 +23,13 @@ module Lasp
       head, *tail = *form
 
       case head
-      when :def   then def_special_form(tail, env)
-      when :fn    then fn_special_form(tail, env)
-      when :do    then do_special_form(tail, env)
-      when :if    then if_special_form(tail, env)
-      when :quote then quote_special_form(tail, env)
-      when :macro then macro_special_form(tail, env)
+      when :def     then def_special_form(tail, env)
+      when :fn      then fn_special_form(tail, env)
+      when :do      then do_special_form(tail, env)
+      when :if      then if_special_form(tail, env)
+      when :quote   then quote_special_form(tail, env)
+      when :macro   then macro_special_form(tail, env)
+      when :require then require_special_form(tail, env)
       else call_function(head, tail, env)
       end
     end
@@ -74,6 +76,11 @@ module Lasp
     def macro_special_form(form, env)
       params, func = form
       Macro.new(params, func, env)
+    end
+
+    def require_special_form(form, env)
+      path = form.first
+      Lasp::execute_file(File.expand_path(path, __dir__), env)
     end
   end
 end

--- a/lib/lasp/repl.rb
+++ b/lib/lasp/repl.rb
@@ -11,13 +11,15 @@ module Lasp
     def run
       trap("SIGINT") { puts "\n\nBye!"; exit }
 
+      env = Lasp::env_with_stdlib
+
       puts "((( Läsp v#{Lasp::VERSION} REPL (ctrl+c to exit) )))\n\n"
       loop do
         begin
           history = true
           input   = Readline.readline(prompt, history).to_s
           input   = autoclose_parentheses(input)
-          result  = Lasp::execute(input)
+          result  = Lasp::execute(input, env)
           print_result(result)
         rescue => error
           print_error(error)

--- a/spec/lib/lasp/corelib_spec.rb
+++ b/spec/lib/lasp/corelib_spec.rb
@@ -154,14 +154,5 @@ module Lasp
     it "interop" do
       expect(CORELIB[:"."].("01011101", "to_i", 2)).to eq 93
     end
-
-    it "require" do
-      path          = "./path/lasp_file.lasp"
-      expected_path = File.expand_path("../../../lib/lasp/path/lasp_file.lasp", __dir__)
-
-      expect(Lasp).to receive(:execute_file).with(expected_path)
-
-      CORELIB[:require].(path)
-    end
   end
 end

--- a/spec/lib/lasp/fn_spec.rb
+++ b/spec/lib/lasp/fn_spec.rb
@@ -4,12 +4,12 @@ require "lasp/fn"
 module Lasp
   describe Fn do
     it "interprets its body with arguments set in the environment" do
-      fn = described_class.new([:a, :b], [:+, :a, :b], Lasp::global_env)
+      fn = described_class.new([:a, :b], [:+, :a, :b], Lasp::env_with_corelib)
       expect(fn.(3, 4)).to eq 7
     end
 
     it "is inspectable" do
-      fn = described_class.new([:a, :b, :&, :c], [:+, :a, :b], {})
+      fn = described_class.new([:a, :b, :&, :c], [:+, :a, :b], double)
       expect(fn.inspect).to eq "#<Fn (a b & c)>"
     end
   end

--- a/spec/lib/lasp/interpreter_spec.rb
+++ b/spec/lib/lasp/interpreter_spec.rb
@@ -1,58 +1,58 @@
-require "lasp/interpreter"
-require "lasp/env"
-require "lasp/parser"
+require "lasp"
 require "tempfile"
-
-def lasp_eval(program, env = Lasp::global_env)
-  Lasp::Interpreter.eval(Lasp::Parser.parse(program), env)
-end
 
 module Lasp
   describe Interpreter do
+    let(:env) { Lasp::env_with_corelib }
+
+    def execute(program, _env = env)
+      Lasp::execute(program, _env)
+    end
+
     it "handles simple forms" do
-      expect(lasp_eval("(+ 1 1)")).to eq 2
+      expect(execute("(+ 1 1)")).to eq 2
     end
 
     it "handles nested forms" do
-      expect(lasp_eval("(+ 1 (+ 2 2))")).to eq 5
+      expect(execute("(+ 1 (+ 2 2))")).to eq 5
     end
 
     it "raises a NameError when trying to resolve a non existing symbol" do
-      expect { lasp_eval("not-here") }.to raise_error(Lasp::NameError, /not-here is not present in this context/)
+      expect { execute("not-here") }.to raise_error(Lasp::NameError, /not-here is not present in this context/)
     end
 
     describe "special forms" do
       describe "def" do
         it "defines values in the environment" do
-          lasp_eval("(def five 5)")
+          execute("(def five 5)")
 
-          expect(Lasp::global_env[:five]).to eq 5
+          expect(env.fetch(:five)).to eq 5
         end
 
         it "returns the value it sets" do
-          expect(lasp_eval("(def five 5)")).to eq 5
+          expect(execute("(def five 5)")).to eq 5
         end
 
         it "only allows defining symbols" do
-          expect { lasp_eval("(def \"str\" 5)") }.to raise_error(Lasp::ArgumentError)
-          expect { lasp_eval("(def (list) 5)") }.to raise_error(Lasp::ArgumentError)
+          expect { execute("(def \"str\" 5)") }.to raise_error(Lasp::ArgumentError)
+          expect { execute("(def (list) 5)") }.to raise_error(Lasp::ArgumentError)
         end
       end
 
       describe "fn" do
         it "creates a function" do
-          expect(lasp_eval("(fn (x) (+ x 1))")).to be_a Fn
+          expect(execute("(fn (x) (+ x 1))")).to be_a Fn
         end
 
         it "enforces arity" do
           expect {
-            lasp_eval("((fn (x) (+ x 1)) 3 6)")
+            execute("((fn (x) (+ x 1)) 3 6)")
           }.to raise_error(Lasp::ArgumentError, "wrong number of arguments (2 for 1)")
         end
 
         it "executes defined functions" do
-          lasp_eval("(def inc (fn (x) (+ x 1)))")
-          expect(lasp_eval("(inc 1)")).to eq 2
+          execute("(def inc (fn (x) (+ x 1)))")
+          expect(execute("(inc 1)")).to eq 2
         end
 
         it "handles closures" do
@@ -61,40 +61,40 @@ module Lasp
           # invocation; this is what the outer parenthesis are for: to execute
           # the inner function too. What is important here is that the inner
           # function has access to the environment in the outer one.
-          expect(lasp_eval("(((fn (x) (fn () x)) 42))")).to eq 42
+          expect(execute("(((fn (x) (fn () x)) 42))")).to eq 42
         end
       end
 
       describe "do" do
         it "executes multiple statements in order" do
           mock_fn  = spy
-          test_env = { test: mock_fn }
+          test_env = Env.new({ test: mock_fn })
 
-          lasp_eval("(do (test 1) (test 2))", test_env)
+          execute("(do (test 1) (test 2))", test_env)
 
           expect(mock_fn).to have_received(:call).with(1).ordered
           expect(mock_fn).to have_received(:call).with(2).ordered
         end
 
         it "returns the value of the last statement" do
-          expect(lasp_eval("(do (+ 1 1) (+ 1 2))")).to eq 3
+          expect(execute("(do (+ 1 1) (+ 1 2))")).to eq 3
         end
       end
 
       describe "if" do
         it "returns the result of the correct form" do
-          expect(lasp_eval("(if (= 1 1) true false)")).to eq true
-          expect(lasp_eval("(if (= 1 2) true false)")).to eq false
-          expect(lasp_eval("(if (= 1 2) true)")).to eq nil
+          expect(execute("(if (= 1 1) true false)")).to eq true
+          expect(execute("(if (= 1 2) true false)")).to eq false
+          expect(execute("(if (= 1 2) true)")).to eq nil
         end
 
         it "does not evaluate the other form" do
           # This is different than simply not returning its result, the other
           # form cannot even be evaluated.
           mock_fn  = spy
-          test_env = Lasp::global_env.merge({ test: mock_fn })
+          test_env = env.merge({ test: mock_fn })
 
-          lasp_eval('(if (= 1 1) true (test "not evaled!"))', test_env)
+          execute('(if (= 1 1) true (test "not evaled!"))', test_env)
 
           expect(mock_fn).not_to have_received(:call)
         end
@@ -102,31 +102,42 @@ module Lasp
 
       describe "quote" do
         it "returns symbol without evaluating it" do
-          expect(lasp_eval("(quote f)")).to eq :f
+          expect(execute("(quote f)")).to eq :f
         end
 
         it "returns form without evaluating it" do
-          expect(lasp_eval("(quote (f 1 2))")).to eq [:f, 1, 2]
+          expect(execute("(quote (f 1 2))")).to eq [:f, 1, 2]
         end
 
         it "only quotes the first argument" do
-          expect(lasp_eval("(quote f g)")).to eq :f
+          expect(execute("(quote f g)")).to eq :f
         end
       end
 
       describe "macro" do
         it "creates macros" do
-          expect(lasp_eval("(macro (x) x)")).to be_a Macro
+          expect(execute("(macro (x) x)")).to be_a Macro
         end
 
         it "gives macros unevaluated forms as arguments" do
-          expect(lasp_eval("((macro (one op two) (list op one two)) 1 + 2)")).to eq 3
+          expect(execute("((macro (one op two) (list op one two)) 1 + 2)")).to eq 3
+        end
+      end
+
+      describe "require" do
+        it "executes a file" do
+          path          = "./path/lasp_file.lasp"
+          expected_path = File.expand_path("../../../lib/lasp/path/lasp_file.lasp", __dir__)
+
+          expect(Lasp).to receive(:execute_file).with(expected_path, env)
+
+          execute("(require \"#{path}\")")
         end
       end
     end
 
     it "does ruby interop" do
-      expect(lasp_eval('(. "hello" :upcase)')).to eq "HELLO"
+      expect(execute('(. "hello" :upcase)')).to eq "HELLO"
     end
 
     it "requires files" do
@@ -134,8 +145,8 @@ module Lasp
         file.write("(def test true)")
         file.rewind
 
-        lasp_eval("(require \"#{file.path}\")")
-        expect(lasp_eval("test")).to eq true
+        execute(%Q{ (require "#{file.path}") })
+        expect(execute("test")).to eq true
       end
     end
   end

--- a/spec/lib/lasp/stdlib_spec.rb
+++ b/spec/lib/lasp/stdlib_spec.rb
@@ -1,176 +1,181 @@
 require "lasp"
-Lasp::load_stdlib!
 
 describe "stdlib" do
+  let(:env) { Lasp::env_with_stdlib }
+
+  def execute(program)
+    Lasp::execute(program, env)
+  end
+
   it "aliases" do
-    expect(Lasp::execute("first")).to eq Lasp::CORELIB[:head]
-    expect(Lasp::execute("rest")).to eq Lasp::CORELIB[:tail]
+    expect(execute("first")).to eq Lasp::CORELIB[:head]
+    expect(execute("rest")).to eq Lasp::CORELIB[:tail]
   end
 
   it "inc" do
-    expect(Lasp::execute("(inc 5)")).to eq 6
+    expect(execute("(inc 5)")).to eq 6
   end
 
   it "dec" do
-    expect(Lasp::execute("(dec 5)")).to eq 4
+    expect(execute("(dec 5)")).to eq 4
   end
 
   it "nil?" do
-    expect(Lasp::execute("(nil? (list))")).to eq false
-    expect(Lasp::execute("(nil? false)")).to eq false
-    expect(Lasp::execute("(nil? nil)")).to eq true
+    expect(execute("(nil? (list))")).to eq false
+    expect(execute("(nil? false)")).to eq false
+    expect(execute("(nil? nil)")).to eq true
   end
 
   it "empty?" do
-    expect(Lasp::execute("(empty? (list nil))")).to eq false
-    expect(Lasp::execute("(empty? (list))")).to eq true
+    expect(execute("(empty? (list nil))")).to eq false
+    expect(execute("(empty? (list))")).to eq true
   end
 
   it "not=" do
-    expect(Lasp::execute("(not= 2 2 3)")).to eq true
-    expect(Lasp::execute("(not= 2 2 2)")).to eq false
+    expect(execute("(not= 2 2 3)")).to eq true
+    expect(execute("(not= 2 2 2)")).to eq false
   end
 
   it "second" do
-    expect(Lasp::execute("(second (list 1 2 3))")).to eq 2
-    expect(Lasp::execute("(second (list 1))")).to eq nil
+    expect(execute("(second (list 1 2 3))")).to eq 2
+    expect(execute("(second (list 1))")).to eq nil
   end
 
   it "mod" do
-    expect(Lasp::execute("(mod 133 51)")).to eq 31
+    expect(execute("(mod 133 51)")).to eq 31
   end
 
   it "complement" do
-    expect(Lasp::execute("((complement empty?) (list 1))")).to eq true
+    expect(execute("((complement empty?) (list 1))")).to eq true
   end
 
   it "even?" do
-    expect(Lasp::execute("(even? 7)")).to eq false
-    expect(Lasp::execute("(even? 4)")).to eq true
+    expect(execute("(even? 7)")).to eq false
+    expect(execute("(even? 4)")).to eq true
   end
 
   it "odd?" do
-    expect(Lasp::execute("(odd? 7)")).to eq true
-    expect(Lasp::execute("(odd? 4)")).to eq false
+    expect(execute("(odd? 7)")).to eq true
+    expect(execute("(odd? 4)")).to eq false
   end
 
   it "zero?" do
-    expect(Lasp::execute("(zero? 0)")).to eq true
-    expect(Lasp::execute("(zero? 1)")).to eq false
+    expect(execute("(zero? 0)")).to eq true
+    expect(execute("(zero? 1)")).to eq false
   end
 
   it "len" do
-    expect(Lasp::execute("(len (list 1 2 3 4 5))")).to eq 5
+    expect(execute("(len (list 1 2 3 4 5))")).to eq 5
   end
 
   it "nth" do
-    expect(Lasp::execute("(nth 2 (list 0 1 2 3 4))")).to eq 2
+    expect(execute("(nth 2 (list 0 1 2 3 4))")).to eq 2
   end
 
   it "last" do
-    expect(Lasp::execute("(last (list 0 1 2 3 4))")).to eq 4
+    expect(execute("(last (list 0 1 2 3 4))")).to eq 4
   end
 
   it "reverse" do
-    expect(Lasp::execute("(reverse (list 1 2 3))")).to eq [3, 2, 1]
+    expect(execute("(reverse (list 1 2 3))")).to eq [3, 2, 1]
   end
 
   it "map" do
-    expect(Lasp::execute("(map inc (list 1 2 3))")).to eq [2, 3, 4]
+    expect(execute("(map inc (list 1 2 3))")).to eq [2, 3, 4]
   end
 
   it "reduce" do
-    expect(Lasp::execute("(reduce + 0 (list 1 2 3))")).to eq 6
-    expect(Lasp::execute("(reduce * 1 (list 5 10))")).to eq 50
+    expect(execute("(reduce + 0 (list 1 2 3))")).to eq 6
+    expect(execute("(reduce * 1 (list 5 10))")).to eq 50
   end
 
   it "filter" do
-    expect(Lasp::execute("(filter odd? (list 1 2 3))")).to eq [1, 3]
+    expect(execute("(filter odd? (list 1 2 3))")).to eq [1, 3]
   end
 
   it "sum" do
-    expect(Lasp::execute("(sum (list 5 10 15))")).to eq 30
+    expect(execute("(sum (list 5 10 15))")).to eq 30
   end
 
   it "take" do
-    expect(Lasp::execute("(take 2 (list 1 2 3 4))")).to eq [1, 2]
+    expect(execute("(take 2 (list 1 2 3 4))")).to eq [1, 2]
   end
 
   it "drop" do
-    expect(Lasp::execute("(drop 2 (list 1 2 3 4))")).to eq [3, 4]
+    expect(execute("(drop 2 (list 1 2 3 4))")).to eq [3, 4]
   end
 
   it "range" do
-    expect(Lasp::execute("(range 0 10)")).to eq (0...10).to_a
-    expect(Lasp::execute("(range 10 0)")).to eq []
+    expect(execute("(range 0 10)")).to eq (0...10).to_a
+    expect(execute("(range 10 0)")).to eq []
   end
 
   it "max" do
-    expect(Lasp::execute("(max (list 4 6 1 5 3))")).to eq 6
+    expect(execute("(max (list 4 6 1 5 3))")).to eq 6
   end
 
   it "min" do
-    expect(Lasp::execute("(min (list 4 6 1 5 3))")).to eq 1
+    expect(execute("(min (list 4 6 1 5 3))")).to eq 1
   end
 
   it "every" do
-    expect(Lasp::execute('(every 2 (list 1 2 3 4 5))')).to eq [1, 3, 5]
-    expect(Lasp::execute('(every 3 (list 1 2 3 4 5))')).to eq [1, 4]
+    expect(execute('(every 2 (list 1 2 3 4 5))')).to eq [1, 3, 5]
+    expect(execute('(every 3 (list 1 2 3 4 5))')).to eq [1, 4]
   end
 
   it "text" do
-    expect(Lasp::execute('(text "one " 1 ", two " 2)')).to eq "one 1, two 2"
+    expect(execute('(text "one " 1 ", two " 2)')).to eq "one 1, two 2"
   end
 
   it "text->list" do
-    expect(Lasp::execute('(text->list "abcdef")')).to eq %w[ a b c d e f ]
+    expect(execute('(text->list "abcdef")')).to eq %w[ a b c d e f ]
   end
 
   it "list->text" do
-    expect(Lasp::execute("(list->text (list 1 2 3 4))")).to eq "1234"
+    expect(execute("(list->text (list 1 2 3 4))")).to eq "1234"
   end
 
   it "->text" do
-    expect(Lasp::execute("(->text 5)")).to eq "5"
+    expect(execute("(->text 5)")).to eq "5"
   end
 
   it "->integer" do
-    expect(Lasp::execute("(->integer :5)")).to eq 5
+    expect(execute("(->integer :5)")).to eq 5
   end
 
   it "->decimal" do
-    expect(Lasp::execute('(->decimal "5.5")')).to eq 5.5
+    expect(execute('(->decimal "5.5")')).to eq 5.5
   end
 
   it "pipe" do
-    expect(Lasp::execute("(pipe 5 inc inc dec ->text)")).to eq "6"
+    expect(execute("(pipe 5 inc inc dec ->text)")).to eq "6"
   end
 
   it "reverse-text" do
-    expect(Lasp::execute('(reverse-text "hello")')).to eq "olleh"
+    expect(execute('(reverse-text "hello")')).to eq "olleh"
   end
 
   it "prompt" do
     expect(STDOUT).to receive(:print).with("Question: ")
     allow(STDIN).to receive(:gets).and_return("answer\n")
 
-    expect(Lasp::execute('(prompt "Question: ")')).to eq "answer"
+    expect(execute('(prompt "Question: ")')).to eq "answer"
   end
 
   describe "println" do
     it "prints its argument with a newline" do
       expect(STDOUT).to receive(:print).with("test\n")
-      Lasp::execute('(println "test")')
+      execute('(println "test")')
     end
 
     it "prints several arguments on a line" do
       expect(STDOUT).to receive(:print).with("onetwothree\n")
-      Lasp::execute('(println :one :two :three)')
+      execute('(println :one :two :three)')
     end
 
     it "prints a single newline when given no arguments" do
       expect(STDOUT).to receive(:print).with("\n")
-      Lasp::execute('(println)')
+      execute('(println)')
     end
   end
 end

--- a/spec/lib/lasp/stdmacros_spec.rb
+++ b/spec/lib/lasp/stdmacros_spec.rb
@@ -1,11 +1,16 @@
 require "lasp"
-Lasp::load_stdlib!
-
-def macroexpand(code)
-  Lasp::execute("(macroexpand #{code})")
-end
 
 describe "stdmacros" do
+  let(:env) { Lasp::env_with_stdlib }
+
+  def macroexpand(program)
+    execute("(macroexpand #{program})")
+  end
+
+  def execute(program)
+    Lasp::execute(program, env)
+  end
+
   describe "defm" do
     it "produces the expected form" do
       given    = macroexpand("(defm m (form) (reverse form))")
@@ -14,8 +19,8 @@ describe "stdmacros" do
     end
 
     it "creates a named macro" do
-      Lasp::execute("(defm test-macro (x) x)")
-      expect(Lasp::execute("test-macro").inspect).to eq "#<Macro (x)>"
+      execute("(defm test-macro (x) x)")
+      expect(execute("test-macro").inspect).to eq "#<Macro (x)>"
     end
   end
 
@@ -27,8 +32,8 @@ describe "stdmacros" do
     end
 
     it "creates a named function" do
-      Lasp::execute("(defn test-fn (x) x)")
-      expect(Lasp::execute("test-fn").inspect).to eq "#<Fn (x)>"
+      execute("(defn test-fn (x) x)")
+      expect(execute("test-fn").inspect).to eq "#<Fn (x)>"
     end
   end
 
@@ -45,7 +50,7 @@ describe "stdmacros" do
               two (+ 1 1))
           (+ one two))
       LASP
-      expect(Lasp::execute(code)).to eq 3
+      expect(execute(code)).to eq 3
     end
 
     it "sets an empty binding to nil" do
@@ -56,7 +61,7 @@ describe "stdmacros" do
           (+ one two)
           three)
       LASP
-      expect(Lasp::execute(code)).to eq nil
+      expect(execute(code)).to eq nil
     end
 
     it "allows access to previous bindings" do
@@ -66,7 +71,7 @@ describe "stdmacros" do
           two)
       LASP
 
-      expect(Lasp::execute(code)).to eq 2
+      expect(execute(code)).to eq 2
     end
 
     it "takes the bindings out of scope as soon as the let ends" do
@@ -75,7 +80,7 @@ describe "stdmacros" do
           (let (one 1))
           (println one))
       LASP
-      expect { Lasp::execute(code) }.to raise_error(Lasp::NameError, /one/)
+      expect { execute(code) }.to raise_error(Lasp::NameError, /one/)
     end
   end
 
@@ -87,38 +92,38 @@ describe "stdmacros" do
     end
 
     it "returns the unevaluated result of a macro" do
-      form = Lasp::execute("(macroexpand (defn test-fn (x) x))")
+      form = execute("(macroexpand (defn test-fn (x) x))")
       expect(form).to eq [:def, :"test-fn", [:fn, [:x], [:do, :x]]]
     end
   end
 
   describe "or" do
     it "returns nil when given no arguments" do
-      expect(Lasp::execute("(or)")).to eq nil
+      expect(execute("(or)")).to eq nil
     end
 
     it "returns the last value if no truthy values are present" do
-      expect(Lasp::execute('(or nil nil false)')).to eq false
+      expect(execute('(or nil nil false)')).to eq false
     end
 
     it "returns the first truthy value it valuates" do
       expect(STDOUT).not_to receive(:print)
-      expect(Lasp::execute('(or (not true) 42 (println "nope"))')).to eq 42
+      expect(execute('(or (not true) 42 (println "nope"))')).to eq 42
     end
   end
 
   describe "and" do
     it "returns true when given no arguments" do
-      expect(Lasp::execute("(and)")).to eq true
+      expect(execute("(and)")).to eq true
     end
 
     it "returns the last value if no falsy values are present" do
-      expect(Lasp::execute('(and true true 42)')).to eq 42
+      expect(execute('(and true true 42)')).to eq 42
     end
 
     it "returns the first falsy value it valuates" do
       expect(STDOUT).not_to receive(:print)
-      expect(Lasp::execute('(and 42 false (println "nope"))')).to eq false
+      expect(execute('(and 42 false (println "nope"))')).to eq false
     end
   end
 end


### PR DESCRIPTION
This is a very big refactoring, but cleans up the code in many ways:

- The env lifetime is now much more explicit, the `global_env` was very
  shady.

- The env has been promoted to a proper `Env` object (which still just
  delegates to a Hash, but is a proper object and significantly narrows
  down the messages it responds to)

- `Env` is no longer responsible for loading the core lib, `lasp.rb` now
  handles both core and standard library loading with the
  `env_with_corelib` and `env_with_stdlib` methods (which unlike
  global_env create fresh environments every time).

- `load_stdlib!` is now gone since it relied on `global_env`.

- `require` had to become a special form to be able to pass the env
  along, this also relied on `global_env`.

- Tests are noticeably slower since they now create new environments for
  every test. This was expected, and they still run in under half a
  second so it's not a big deal. Actual performance should be
  unaffected, in that case you are still using the same env the entire
  execution.
