### PR TITLE
Functions get named when they first get def:ed

### DIFF
--- a/lib/lasp/fn.rb
+++ b/lib/lasp/fn.rb
@@ -4,7 +4,7 @@ require "lasp/errors"
 
 module Lasp
   class Fn
-    attr_reader :params, :body, :env
+    attr_reader :params, :body, :env, :name
 
     def initialize(params, body, env)
       @params = ParamsBuilder.build(params)
@@ -17,14 +17,21 @@ module Lasp
     end
 
     def inspect
-      class_name = self.class.name.split("::").last
-      "#<#{class_name} #{params}>"
+      "#<#{ [class_name, name, params].compact.join(" ") }>"
+    end
+
+    def name=(new_name)
+      @name = new_name if name.nil?
     end
 
     private
 
     def env_with_args(args)
       env.merge(params.with_args(args))
+    end
+
+    def class_name
+      self.class.name.split("::").last
     end
   end
 end

--- a/lib/lasp/fn.rb
+++ b/lib/lasp/fn.rb
@@ -17,7 +17,7 @@ module Lasp
     end
 
     def inspect
-      "#<#{ [class_name, name, params].compact.join(" ") }>"
+      "#<#{[class_name, name, params].compact.join(' ')}>"
     end
 
     def name=(new_name)

--- a/lib/lasp/interpreter.rb
+++ b/lib/lasp/interpreter.rb
@@ -52,7 +52,9 @@ module Lasp
     def def_special_form(form, env)
       key, value = form
       fail ArgumentError, "you can only def symbols" unless key.is_a?(Symbol)
-      env[key] = eval(value, env)
+      env[key] = eval(value, env).tap do |result|
+        result.name = key if result.respond_to?(:name=)
+      end
     end
 
     def fn_special_form(form, env)

--- a/spec/lib/lasp/fn_spec.rb
+++ b/spec/lib/lasp/fn_spec.rb
@@ -12,5 +12,26 @@ module Lasp
       fn = described_class.new([:a, :b, :&, :c], [:+, :a, :b], double)
       expect(fn.inspect).to eq "#<Fn (a b & c)>"
     end
+
+    describe "nameablility" do
+      let(:fn) {
+        described_class.new([:arg], [], double).tap do |fn|
+          fn.name = :"test-function"
+        end
+      }
+
+      it "is nameable" do
+        expect(fn.name).to eq :"test-function"
+      end
+
+      it "can only be named once" do
+        fn.name = :"other-name"
+        expect(fn.name).to eq :"test-function"
+      end
+
+      it "includes the name in the inspect output when it exists" do
+        expect(fn.inspect).to eq "#<Fn test-function (arg)>"
+      end
+    end
   end
 end

--- a/spec/lib/lasp/interpreter_spec.rb
+++ b/spec/lib/lasp/interpreter_spec.rb
@@ -52,6 +52,11 @@ module Lasp
           expect { execute("(def \"str\" 5)") }.to raise_error(Lasp::ArgumentError)
           expect { execute("(def (list) 5)") }.to raise_error(Lasp::ArgumentError)
         end
+
+        it "names functions things" do
+          defined_function = execute("(def my-func (fn () nil))")
+          expect(defined_function.name).to eq :"my-func"
+        end
       end
 
       describe "fn" do

--- a/spec/lib/lasp/stdmacros_spec.rb
+++ b/spec/lib/lasp/stdmacros_spec.rb
@@ -20,7 +20,7 @@ describe "stdmacros" do
 
     it "creates a named macro" do
       execute("(defm test-macro (x) x)")
-      expect(execute("test-macro").inspect).to eq "#<Macro (x)>"
+      expect(execute("test-macro").inspect).to eq "#<Macro test-macro (x)>"
     end
   end
 
@@ -33,7 +33,7 @@ describe "stdmacros" do
 
     it "creates a named function" do
       execute("(defn test-fn (x) x)")
-      expect(execute("test-fn").inspect).to eq "#<Fn (x)>"
+      expect(execute("test-fn").inspect).to eq "#<Fn test-fn (x)>"
     end
   end
 


### PR DESCRIPTION
This can be seen when they are inspected
- [ ] Documentation
- [ ] Use this in error messages
